### PR TITLE
Update base haproxy image

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercloud/haproxy:1.5.1
+FROM dockercloud/haproxy:1.6.1
 
 RUN apk add --update \
 		bash \


### PR DESCRIPTION
The primary motivation is that `dockercloud/haproxy:1.5.1` in legacy link mode does not reload. `/reload.sh`sends a `USR1` signal, but that just causes a `User reload is not supported in legacy link mode` log message.

With `dockercloud/haproxy:1.6.1`, haproxy picks up the new certificates for new domains as they are added, even when started with `docker run --link ...`.