### PR TITLE
Upgrade HAProxy image + fix tini => /sbin/tini alpine deprecation warning

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercloud/haproxy:1.5.1
+FROM dockercloud/haproxy:1.6.2
 
 RUN apk add --update \
 		bash \

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV PATH="/opt/letsencrypt/bin:$PATH"
 COPY . /opt/letsencrypt/
 RUN ln -fs /opt/letsencrypt/bin/update-certs.sh /etc/periodic/daily/
 
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["entrypoint.sh", "crond", "-f"]


### PR DESCRIPTION
thanks @mrmachine: really nice implementation
thanks @dfanchon for the updates

those changes should be in the main repo



