### PR TITLE
Fix missing argparse dependency

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:edge
 RUN apk add --update \
 		bash \
 		certbot \
+		py2-pip \
 		tini \
 	&& rm -rf /var/cache/apk/*
 
@@ -14,6 +15,7 @@ ENV VIRTUAL_HOST_WEIGHT="999"
 ENV PATH="/opt/letsencrypt/bin:$PATH"
 
 COPY . /opt/letsencrypt/
+RUN pip install --upgrade setuptools argparse
 RUN ln -fs /opt/letsencrypt/bin/update-certs.sh /etc/periodic/daily/
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
Fixes the error about the missing argparse dependency.

Argparse dependency for certbot details here: [certbot issue](https://github.com/certbot/certbot/issues/4485)

Error:

```
[letsencrypt-1]2017-04-18T07:39:26.092479104Z Serving HTTP on 0.0.0.0 port 80 ...
[letsencrypt-1]2017-04-18T07:39:27.401718147Z Traceback (most recent call last):
[letsencrypt-1]2017-04-18T07:39:27.402024418Z   File "/usr/bin/certbot", line 6, in <module>
[letsencrypt-1]2017-04-18T07:39:27.402133259Z     from pkg_resources import load_entry_point
[letsencrypt-1]2017-04-18T07:39:27.402329241Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
[letsencrypt-1]2017-04-18T07:39:27.403815662Z     @_call_aside
[letsencrypt-1]2017-04-18T07:39:27.403880331Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
[letsencrypt-1]2017-04-18T07:39:27.404961658Z     f(*args, **kwargs)
[letsencrypt-1]2017-04-18T07:39:27.405022263Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
[letsencrypt-1]2017-04-18T07:39:27.406131845Z     working_set = WorkingSet._build_master()
[letsencrypt-1]2017-04-18T07:39:27.406192643Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
[letsencrypt-1]2017-04-18T07:39:27.406590559Z     ws.require(__requires__)
[letsencrypt-1]2017-04-18T07:39:27.406610393Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
[letsencrypt-1]2017-04-18T07:39:27.407187557Z     needed = self.resolve(parse_requirements(requirements))
[letsencrypt-1]2017-04-18T07:39:27.407287147Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
[letsencrypt-1]2017-04-18T07:39:27.407569317Z     raise DistributionNotFound(req, requirers)
[letsencrypt-1]2017-04-18T07:39:27.407910463Z pkg_resources.DistributionNotFound: The 'argparse' distribution was not found and is required by certbot
[letsencrypt-1]2017-04-18T07:39:27.780185992Z Traceback (most recent call last):
[letsencrypt-1]2017-04-18T07:39:27.780279790Z   File "/usr/bin/certbot", line 6, in <module>
[letsencrypt-1]2017-04-18T07:39:27.780311935Z     from pkg_resources import load_entry_point
[letsencrypt-1]2017-04-18T07:39:27.780321645Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
[letsencrypt-1]2017-04-18T07:39:27.781716598Z     @_call_aside
[letsencrypt-1]2017-04-18T07:39:27.781749354Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
[letsencrypt-1]2017-04-18T07:39:27.782898068Z     f(*args, **kwargs)
[letsencrypt-1]2017-04-18T07:39:27.782923482Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
[letsencrypt-1]2017-04-18T07:39:27.784106772Z     working_set = WorkingSet._build_master()
[letsencrypt-1]2017-04-18T07:39:27.784125837Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
[letsencrypt-1]2017-04-18T07:39:27.784573724Z     ws.require(__requires__)
[letsencrypt-1]2017-04-18T07:39:27.784591532Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
[letsencrypt-1]2017-04-18T07:39:27.784887101Z     needed = self.resolve(parse_requirements(requirements))
[letsencrypt-1]2017-04-18T07:39:27.784904836Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
[letsencrypt-1]2017-04-18T07:39:27.785288016Z     raise DistributionNotFound(req, requirers)
[letsencrypt-1]2017-04-18T07:39:27.785420808Z pkg_resources.DistributionNotFound: The 'argparse' distribution was not found and is required by certbot
[letsencrypt-1]2017-04-18T07:39:28.166769268Z Traceback (most recent call last):
[letsencrypt-1]2017-04-18T07:39:28.166933855Z   File "/usr/bin/certbot", line 6, in <module>
[letsencrypt-1]2017-04-18T07:39:28.167082820Z     from pkg_resources import load_entry_point
[letsencrypt-1]2017-04-18T07:39:28.167120448Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
[letsencrypt-1]2017-04-18T07:39:28.167976614Z     @_call_aside
[letsencrypt-1]2017-04-18T07:39:28.168038069Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
[letsencrypt-1]2017-04-18T07:39:28.169018536Z     f(*args, **kwargs)
[letsencrypt-1]2017-04-18T07:39:28.169131905Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
[letsencrypt-1]2017-04-18T07:39:28.170066356Z     working_set = WorkingSet._build_master()
[letsencrypt-1]2017-04-18T07:39:28.170162717Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
[letsencrypt-1]2017-04-18T07:39:28.170372779Z     ws.require(__requires__)
[letsencrypt-1]2017-04-18T07:39:28.170416569Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
[letsencrypt-1]2017-04-18T07:39:28.170820367Z     needed = self.resolve(parse_requirements(requirements))
[letsencrypt-1]2017-04-18T07:39:28.170840946Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
[letsencrypt-1]2017-04-18T07:39:28.174320434Z     raise DistributionNotFound(req, requirers)
[letsencrypt-1]2017-04-18T07:39:28.174583235Z pkg_resources.DistributionNotFound: The 'argparse' distribution was not found and is required by certbot
[letsencrypt-1]2017-04-18T07:39:28.538703574Z Traceback (most recent call last):
[letsencrypt-1]2017-04-18T07:39:28.538777201Z   File "/usr/bin/certbot", line 6, in <module>
[letsencrypt-1]2017-04-18T07:39:28.538792111Z     from pkg_resources import load_entry_point
[letsencrypt-1]2017-04-18T07:39:28.538800262Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
[letsencrypt-1]2017-04-18T07:39:28.539804563Z     @_call_aside
[letsencrypt-1]2017-04-18T07:39:28.539837098Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
[letsencrypt-1]2017-04-18T07:39:28.540791755Z     f(*args, **kwargs)
[letsencrypt-1]2017-04-18T07:39:28.540857099Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
[letsencrypt-1]2017-04-18T07:39:28.541774913Z     working_set = WorkingSet._build_master()
[letsencrypt-1]2017-04-18T07:39:28.541821031Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
[letsencrypt-1]2017-04-18T07:39:28.542229754Z     ws.require(__requires__)
[letsencrypt-1]2017-04-18T07:39:28.542255252Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
[letsencrypt-1]2017-04-18T07:39:28.542315693Z     needed = self.resolve(parse_requirements(requirements))
[letsencrypt-1]2017-04-18T07:39:28.542339035Z   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
[letsencrypt-1]2017-04-18T07:39:28.542733146Z     raise DistributionNotFound(req, requirers)
[letsencrypt-1]2017-04-18T07:39:28.542817639Z pkg_resources.DistributionNotFound: The 'argparse' distribution was not found and is required by certbot
```