### PR TITLE
change to alpine 3.4

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.4
 
 RUN apk add --update \
 		bash \


### PR DESCRIPTION
The edge version of alpine image had python install issues. Please revert to 3.4
